### PR TITLE
Rename vim-cssfmt to vim-stylefmt.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# vim-cssfmt
+# vim-stylefmt
 
-Format your CSS using [CSSfmt](https://github.com/morishitter/cssfmt) inside Vim.
+Format your stylesheets using [stylefmt](https://github.com/morishitter/stylefmt) inside Vim.
+Stylefmt supports the latest CSS syntax and understands CSS-like syntax such as SCSS, Stylus and Less.
 
 This plugin is heavily inspired by [vim-esformatter](https://github.com/millermedeiros/vim-esformatter).
 
 ## Installation
 
-First you need to install CSSfmt (make sure you have [Node.js](https://nodejs.org/) 
+First you need to install stylefmt (make sure you have [Node.js](https://nodejs.org/)
 installed):
 
 ```
-npm install -g cssfmt
+npm install -g stylefmt
 ```
 
 Then install the plugin:
@@ -18,30 +19,30 @@ Then install the plugin:
 * Manual installation:
   - Copy the files to your `.vim/plugin` directory
 * Pathogen
-  - `cd ~/.vim/bundle && git clone git://github.com/kewah/vim-cssfmt.git`
+  - `cd ~/.vim/bundle && git clone git://github.com/kewah/vim-stylefmt.git`
 * Vundle
-  - Add `Bundle 'kewah/vim-cssfmt'` to `.vimrc`
+  - Add `Bundle 'kewah/vim-stylefmt'` to `.vimrc`
   - Run `:BundleInstall`
 * NeoBundle
-  - Add `NeoBundle 'kewah/vim-cssfmt'` to `.vimrc`
+  - Add `NeoBundle 'kewah/vim-stylefmt'` to `.vimrc`
   - Run `:NeoBundleInstall`
 * vim-plug
-  - Add `Plug 'kewah/vim-cssfmt'` to `.vimrc`
+  - Add `Plug 'kewah/vim-stylefmt'` to `.vimrc`
   - Run `:PlugInstall`
 
 
 ## Usage
 
 In normal mode:
-* `:Cssfmt`: format the whole buffer.
+* `:Stylefmt`: format the whole buffer.
 
 In Visual mode:
-* `:'<,'>CssfmtVisual`: format the selected block.
+* `:'<,'>StylefmtVisual`: format the selected block.
 
 Or by mapping the commands in your `.vimrc`:
 ```
-nnoremap <silent> <leader>cs :Cssfmt<CR>
-vnoremap <silent> <leader>cs :CssfmtVisual<CR>
+nnoremap <silent> <leader>cs :Stylefmt<CR>
+vnoremap <silent> <leader>cs :StylefmtVisual<CR>
 ```
 
 

--- a/doc/cssfmt.txt
+++ b/doc/cssfmt.txt
@@ -1,25 +1,25 @@
-*cssfmt.txt* Automatically format your CSS files.
+*stylefmt.txt* Automatically format your stylesheets.
 
 ===============================================================================
-USAGE                                                             *cssfmt*
+USAGE                                                             *stylefmt*
 
 In normal mode:
-`:Cssfmt`: format the whole buffer.
+`:Stylefmt`: format the whole buffer.
 
 In Visual mode:
-`:'<,'>CssfmtVisual`: format the selected block.
+`:'<,'>StylefmtVisual`: format the selected block.
 
 Or by mapping the commands in your `.vimrc`:
 ```
-nnoremap <silent> <leader>cs :Cssfmt<CR>
-vnoremapap <silent> <leader>cs :CssfmtVisual<CR>
+nnoremap <silent> <leader>cs :Stylefmt<CR>
+vnoremapap <silent> <leader>cs :StylefmtVisual<CR>
 ```
 
 
 ===============================================================================
 REPOSITORY
 
-https://github.com/kewah/vim-cssfmt
+https://github.com/kewah/vim-stylefmt
 
 
 ===============================================================================

--- a/plugin/cssfmt.vim
+++ b/plugin/cssfmt.vim
@@ -1,7 +1,7 @@
 " ============================================================================
-" File:        cssfmt.vim
+" File:        stylefmt.vim
 " Maintainer:  Antoine Lehurt
-" Description: Expose commands to execute the cssfmt binary on normal and
+" Description: Expose commands to execute the stylefmt binary on normal and
 "              visual modes.
 " Last Change: 2015-08-14
 " License:     This program is free software. It comes without any warranty,
@@ -13,27 +13,27 @@
 " ============================================================================
 
 " avoid installing twice
-if exists('g:loaded_cssfmt') || &compatible
+if exists('g:loaded_stylefmt') || &compatible
   finish
 endif
 
 " check if debugging is turned off
-if !exists('g:cssfmt_debug')
-  let g:loaded_cssfmt = 1
+if !exists('g:stylefmt_debug')
+  let g:loaded_stylefmt = 1
 end
 
-function! s:CssfmtNormal()
+function! s:StylefmtNormal()
   " store current cursor position and change the working directory
   let win_view = winsaveview()
   let file_wd = expand('%:p:h')
   let current_wd = getcwd()
   execute ':lcd' . file_wd
 
-  " pass whole buffer content to cssfmt
-  let output = system('cssfmt', join(getline(1,'$'), "\n"))
+  " pass whole buffer content to stylefmt
+  let output = system('stylefmt', join(getline(1,'$'), "\n"))
 
   if v:shell_error
-    echom "Error while executing cssfmt! no changes made."
+    echom "Error while executing stylefmt! no changes made."
     echo output
   else
     " delete whole buffer content and append the formatted code
@@ -48,7 +48,7 @@ function! s:CssfmtNormal()
   execute ':lcd' . current_wd
 endfunction
 
-function! s:CssfmtVisual() range
+function! s:StylefmtVisual() range
   " store current cursor position and change the working directory
   let win_view = winsaveview()
   let file_wd = expand('%:p:h')
@@ -59,10 +59,10 @@ function! s:CssfmtVisual() range
   let range_start = line("'<")
   let input = getline("'<", "'>")
 
-  let output = system('cssfmt', join(input, "\n"))
+  let output = system('stylefmt', join(input, "\n"))
 
   if v:shell_error
-    echom 'Error while executing cssfmt! no changes made.'
+    echom 'Error while executing stylefmt! no changes made.'
     echo output
   else
     " delete the old lines
@@ -84,5 +84,5 @@ function! s:CssfmtVisual() range
   execute ':lcd' . current_wd
 endfunction
 
-command! -range=0 -complete=shellcmd Cssfmt call s:CssfmtNormal()
-command! -range=% -complete=shellcmd CssfmtVisual call s:CssfmtVisual()
+command! -range=0 -complete=shellcmd Stylefmt call s:StylefmtNormal()
+command! -range=% -complete=shellcmd StylefmtVisual call s:StylefmtVisual()


### PR DESCRIPTION
Cssfmt has been renamed to Stylefmt. Reflecting that change by renaming vim-cssfmt to vim-stylefmt.
This should help with long-term compatibility and with SEO.

@kewah you'll have to rename the branch `kewah/vim-cssfmt` to `kewah/vim-stylefmt`.

